### PR TITLE
feat(transport): add FileSystem device type and expose queue module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,8 @@ extern crate alloc;
 
 pub mod device;
 mod hal;
-mod queue;
+/// Virtqueue implementation used by virtio device drivers.
+pub mod queue;
 pub mod transport;
 mod volatile;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -160,6 +160,7 @@ pub enum DeviceType {
     Pstore = 22,
     IOMMU = 23,
     Memory = 24,
+    FileSystem = 26,
 }
 
 impl From<u32> for DeviceType {
@@ -187,6 +188,7 @@ impl From<u32> for DeviceType {
             22 => DeviceType::Pstore,
             23 => DeviceType::IOMMU,
             24 => DeviceType::Memory,
+            26 => DeviceType::FileSystem,
             _ => DeviceType::Invalid,
         }
     }


### PR DESCRIPTION
- Add`FileSystem`variant to`DeviceType`enum with value 26
- Update`From<u32>`implementation to handle new device type
- Change`queue`module from private to public with documentation comment