### PR TITLE
feat(transport): add Pmem device type (ID 27)

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -161,6 +161,7 @@ pub enum DeviceType {
     IOMMU = 23,
     Memory = 24,
     FileSystem = 26,
+    Pmem = 27,
 }
 
 impl From<u32> for DeviceType {
@@ -189,6 +190,7 @@ impl From<u32> for DeviceType {
             23 => DeviceType::IOMMU,
             24 => DeviceType::Memory,
             26 => DeviceType::FileSystem,
+            27 => DeviceType::Pmem,
             _ => DeviceType::Invalid,
         }
     }


### PR DESCRIPTION
Add VirtIO Pmem (Persistent Memory) device type to the `DeviceType` enum with its standard device ID 27.

## Changes

- Add `Pmem = 27` variant to `DeviceType` enum
- Add `27 => DeviceType::Pmem` match arm in `From<u32>` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)